### PR TITLE
Updated nrtFilenameRegex for MODIS daily collections

### DIFF
--- a/dataset-config/MODIS_AQUA_L3_SST_MID-IR_DAILY_4KM_NIGHTTIME_V2019.0.cfg
+++ b/dataset-config/MODIS_AQUA_L3_SST_MID-IR_DAILY_4KM_NIGHTTIME_V2019.0.cfg
@@ -3,7 +3,7 @@
   "operaHLSTreatment": false,
   "latVar": "lat",
   "lonVar": "lon",
-  "nrtFilenameRegex": "*.NRT",
+  "nrtFilenameRegex": ".*.NRT",
   "imgVariables": [
     {"id": "sst4", "title": "4um Sea Surface Temperature", "units": "degree_C", "min": "-1000", "max": "10000"}
   ],

--- a/dataset-config/MODIS_AQUA_L3_SST_MID-IR_DAILY_9KM_NIGHTTIME_V2019.0.cfg
+++ b/dataset-config/MODIS_AQUA_L3_SST_MID-IR_DAILY_9KM_NIGHTTIME_V2019.0.cfg
@@ -3,7 +3,7 @@
   "operaHLSTreatment": false,
   "latVar": "lat",
   "lonVar": "lon",
-  "nrtFilenameRegex": "*.NRT",
+  "nrtFilenameRegex": ".*.NRT",
   "imgVariables": [
     {"id": "sst4", "title": "4um Sea Surface Temperature", "units": "degree_C", "min": "-1000", "max": "10000"}
   ],

--- a/dataset-config/MODIS_AQUA_L3_SST_THERMAL_DAILY_4KM_DAYTIME_V2019.0.cfg
+++ b/dataset-config/MODIS_AQUA_L3_SST_THERMAL_DAILY_4KM_DAYTIME_V2019.0.cfg
@@ -3,7 +3,7 @@
   "operaHLSTreatment": false,
   "latVar": "lat",
   "lonVar": "lon",
-  "nrtFilenameRegex": "*.NRT",
+  "nrtFilenameRegex": ".*.NRT",
   "imgVariables": [
     {"id": "sst", "title": "Sea Surface Temperature", "units": "degree_C", "min": "-1000", "max": "10000"}
   ],

--- a/dataset-config/MODIS_AQUA_L3_SST_THERMAL_DAILY_4KM_NIGHTTIME_V2019.0.cfg
+++ b/dataset-config/MODIS_AQUA_L3_SST_THERMAL_DAILY_4KM_NIGHTTIME_V2019.0.cfg
@@ -3,7 +3,7 @@
   "operaHLSTreatment": false,
   "latVar": "lat",
   "lonVar": "lon",
-  "nrtFilenameRegex": "*.NRT",
+  "nrtFilenameRegex": ".*.NRT",
   "imgVariables": [
     {"id": "sst", "title": "Sea Surface Temperature", "units": "degree_C", "min": "-1000", "max": "10000"}
   ],

--- a/dataset-config/MODIS_AQUA_L3_SST_THERMAL_DAILY_9KM_DAYTIME_V2019.0.cfg
+++ b/dataset-config/MODIS_AQUA_L3_SST_THERMAL_DAILY_9KM_DAYTIME_V2019.0.cfg
@@ -3,7 +3,7 @@
   "operaHLSTreatment": false,
   "latVar": "lat",
   "lonVar": "lon",
-  "nrtFilenameRegex": "*.NRT",
+  "nrtFilenameRegex": ".*.NRT",
   "imgVariables": [
     {"id": "sst", "title": "Sea Surface Temperature", "units": "degree_C", "min": "-1000", "max": "10000"}
   ],

--- a/dataset-config/MODIS_AQUA_L3_SST_THERMAL_DAILY_9KM_NIGHTTIME_V2019.0.cfg
+++ b/dataset-config/MODIS_AQUA_L3_SST_THERMAL_DAILY_9KM_NIGHTTIME_V2019.0.cfg
@@ -3,7 +3,7 @@
   "operaHLSTreatment": false,
   "latVar": "lat",
   "lonVar": "lon",
-  "nrtFilenameRegex": "*.NRT",
+  "nrtFilenameRegex": ".*.NRT",
   "imgVariables": [
     {"id": "sst", "title": "Sea Surface Temperature", "units": "degree_C", "min": "-1000", "max": "10000"}
   ],

--- a/dataset-config/MODIS_TERRA_L3_SST_MID-IR_DAILY_4KM_NIGHTTIME_V2019.0.cfg
+++ b/dataset-config/MODIS_TERRA_L3_SST_MID-IR_DAILY_4KM_NIGHTTIME_V2019.0.cfg
@@ -3,7 +3,7 @@
   "operaHLSTreatment": false,
   "latVar": "lat",
   "lonVar": "lon",
-  "nrtFilenameRegex": "*.NRT",
+  "nrtFilenameRegex": ".*.NRT",
   "imgVariables": [
     {"id": "sst4", "title": "4um Sea Surface Temperature", "units": "degree_C", "min": "-1000", "max": "10000"}
   ],

--- a/dataset-config/MODIS_TERRA_L3_SST_MID-IR_DAILY_9KM_NIGHTTIME_V2019.0.cfg
+++ b/dataset-config/MODIS_TERRA_L3_SST_MID-IR_DAILY_9KM_NIGHTTIME_V2019.0.cfg
@@ -3,7 +3,7 @@
   "operaHLSTreatment": false,
   "latVar": "lat",
   "lonVar": "lon",
-  "nrtFilenameRegex": "*.NRT",
+  "nrtFilenameRegex": ".*.NRT",
   "imgVariables": [
     {"id": "sst4", "title": "4um Sea Surface Temperature", "units": "degree_C", "min": "-1000", "max": "10000"}
   ],

--- a/dataset-config/MODIS_TERRA_L3_SST_THERMAL_DAILY_4KM_DAYTIME_V2019.0.cfg
+++ b/dataset-config/MODIS_TERRA_L3_SST_THERMAL_DAILY_4KM_DAYTIME_V2019.0.cfg
@@ -3,7 +3,7 @@
   "operaHLSTreatment": false,
   "latVar": "lat",
   "lonVar": "lon",
-  "nrtFilenameRegex": "*.NRT",
+  "nrtFilenameRegex": ".*.NRT",
   "imgVariables": [
     {"id": "sst", "title": "Sea Surface Temperature", "units": "degree_C", "min": "-1000", "max": "10000"}
   ],

--- a/dataset-config/MODIS_TERRA_L3_SST_THERMAL_DAILY_4KM_NIGHTTIME_V2019.0.cfg
+++ b/dataset-config/MODIS_TERRA_L3_SST_THERMAL_DAILY_4KM_NIGHTTIME_V2019.0.cfg
@@ -3,7 +3,7 @@
   "operaHLSTreatment": false,
   "latVar": "lat",
   "lonVar": "lon",
-  "nrtFilenameRegex": "*.NRT",
+  "nrtFilenameRegex": ".*.NRT",
   "imgVariables": [
     {"id": "sst", "title": "Sea Surface Temperature", "units": "degree_C", "min": "-1000", "max": "10000"}
   ],

--- a/dataset-config/MODIS_TERRA_L3_SST_THERMAL_DAILY_9KM_DAYTIME_V2019.0.cfg
+++ b/dataset-config/MODIS_TERRA_L3_SST_THERMAL_DAILY_9KM_DAYTIME_V2019.0.cfg
@@ -3,7 +3,7 @@
   "operaHLSTreatment": false,
   "latVar": "lat",
   "lonVar": "lon",
-  "nrtFilenameRegex": "*.NRT",
+  "nrtFilenameRegex": ".*.NRT",
   "imgVariables": [
     {"id": "sst", "title": "Sea Surface Temperature", "units": "degree_C", "min": "-1000", "max": "10000"}
   ],

--- a/dataset-config/MODIS_TERRA_L3_SST_THERMAL_DAILY_9KM_NIGHTTIME_V2019.0.cfg
+++ b/dataset-config/MODIS_TERRA_L3_SST_THERMAL_DAILY_9KM_NIGHTTIME_V2019.0.cfg
@@ -3,7 +3,7 @@
   "operaHLSTreatment": false,
   "latVar": "lat",
   "lonVar": "lon",
-  "nrtFilenameRegex": "*.NRT",
+  "nrtFilenameRegex": ".*.NRT",
   "imgVariables": [
     {"id": "sst", "title": "Sea Surface Temperature", "units": "degree_C", "min": "-1000", "max": "10000"}
   ],


### PR DESCRIPTION
The Python `re` module is used for interpreting the regex string in the dataset config, so we have to use `.*` instead of `*` as a wildcard. The `*` alone is interpreted as "any number of the previous character and so re.match throws an error if a regex starts with `*` 